### PR TITLE
Fix Issue #8: null property fields

### DIFF
--- a/src/main/java/net/kemitix/spring/common/logging/LogFieldPostProcessor.java
+++ b/src/main/java/net/kemitix/spring/common/logging/LogFieldPostProcessor.java
@@ -30,7 +30,8 @@ public class LogFieldPostProcessor implements BeanPostProcessor {
                     if (name.equals("")) {
                         name = field.getName();
                     }
-                    String value = field.get(bean).toString();
+                    Object rawValue = field.get(bean);
+                    String value = rawValue == null ? "(null)" : rawValue.toString();
                     logger.log(Level.INFO, "{0} : {1}", new Object[]{
                         name, value
                     });

--- a/src/test/java/net/kemitix/spring/common/logging/LogFieldPostProcessorTest.java
+++ b/src/test/java/net/kemitix/spring/common/logging/LogFieldPostProcessorTest.java
@@ -148,6 +148,29 @@ public class LogFieldPostProcessorTest {
         verify(logger, times(0)).log(Level.INFO, "{0} : {1}", new Object[]{"packageDefault", PACKAGE_DEFAULT});
     }
 
+    /**
+     * Test for null field values
+     */
+    @Test
+    public void shouldHandleNullFieldValues() {
+        System.out.println("shoud handle null field values");
+        //given
+        LoggerProvider bean = new TestProperties();
+        setField(bean, "onDisplay", null);
+        Logger logger = mock(Logger.class);
+        setField(bean, "logger", logger);
+
+        //when
+        Object result = postProcessor.postProcessAfterInitialization(bean, null);
+
+        //then
+        assertThat(result, is(bean));
+        verify(logger, times(1)).log(Level.INFO, "{0} : {1}", new Object[]{"visible", VISIBLE});
+        verify(logger, times(1)).log(Level.INFO, "{0} : {1}", new Object[]{"on display", "(null)"});
+        verify(logger, times(0)).log(Level.INFO, "{0} : {1}", new Object[]{"secret", SECRET});
+        verify(logger, times(0)).log(Level.INFO, "{0} : {1}", new Object[]{"packageDefault", PACKAGE_DEFAULT});
+    }
+
     @Getter
     public static class TestProperties implements LoggerProvider {
 


### PR DESCRIPTION
Check for null value in field before attempting to convert it to a String. Nulls are replaced with the String "(null)".