### PR TITLE
Add JdbcDataSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This Java library provides some Components for use with Spring Boot applications
 `LoggerProvider`|Interface to provide a `Logger`
 `@LogField`|Annotation class to indicate fields to be logged
 `JdbcProperties` | Abstract class for holding JDBC `DataSource` properties
+`JdbcDataSource` | `DataSource` wrapper for using a `JdbcProperties` instance
 `Queryable` | Funtional interface for a querying by a String to get a `List`
 
 ## Usage
@@ -128,19 +129,16 @@ This Java library provides some Components for use with Spring Boot applications
 
 Because JdbcProperties implements LoggerProvider, it needs to provide an implementation of Logger getLogger(), which we do using Lombok's @Getter and spring-common's @Log annotations.
 
-Note that the password property, being private in JdbcProperties, is not logged.
+### JdbcDataSource
 
     package foo;
 
     @Component
-    public class FooDataSource extends DriverManagerDataSource {
+    public class FooDataSource extends JdbcDataSource {
 
         @Autowired
         public FooDataSource(FooJdbcProperties properties) {
-            setDriverClassName(properties.getDriver());
-            setUrl(properties.getUrl());
-            setUsername(properties.getUser());
-            setPassword(properties.getPassword());
+            super(properties);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
             <version>1.2.2.RELEASE</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+            <version>1.2.2.RELEASE</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.14.8</version>

--- a/src/main/java/net/kemitix/spring/common/JdbcDataSource.java
+++ b/src/main/java/net/kemitix/spring/common/JdbcDataSource.java
@@ -1,0 +1,19 @@
+package net.kemitix.spring.common;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+public class JdbcDataSource extends DriverManagerDataSource {
+
+    @Autowired
+    public JdbcDataSource(JdbcProperties properties) {
+        String driver = properties.getDriver();
+        if (driver != null && driver.length() > 0) {
+            setDriverClassName(properties.getDriver());
+        }
+        setUrl(properties.getUrl());
+        setUsername(properties.getUser());
+        setPassword(properties.getPassword());
+    }
+
+}

--- a/src/main/java/net/kemitix/spring/common/logging/LogFieldPostProcessor.java
+++ b/src/main/java/net/kemitix/spring/common/logging/LogFieldPostProcessor.java
@@ -20,7 +20,6 @@ public class LogFieldPostProcessor implements BeanPostProcessor {
     public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
         if (bean instanceof LoggerProvider) {
             Logger logger = ((LoggerProvider) bean).getLogger();
-            logger.log(Level.INFO, "Scanning: {0}", beanName);
             ReflectionUtils.doWithFields(bean.getClass(), (Field field) -> {
                 ReflectionUtils.makeAccessible(field);
                 LogField annotation = field.getAnnotation(LogField.class);

--- a/src/test/java/net/kemitix/spring/common/JdbcDataSourceTest.java
+++ b/src/test/java/net/kemitix/spring/common/JdbcDataSourceTest.java
@@ -1,0 +1,132 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Paul Campbell.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package net.kemitix.spring.common;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import org.junit.Before;
+import org.junit.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ *
+ * @author Paul Campbell
+ */
+public class JdbcDataSourceTest {
+
+    private JdbcDataSource dataSource;
+    private JdbcProperties jdbcProperties;
+
+    private static final String PASSWORD = "PASSWORD";
+    private static final String USER = "USER";
+    private static final String URL = "URL";
+    private static final String DRIVER = "net.kemitix.spring.common.JdbcDataSourceTest$TestDriver";
+
+    @Before
+    public void setUp() {
+        jdbcProperties = mock(JdbcProperties.class);
+    }
+
+    @Test
+    public void testConstructorWithNamedDriverClass() {
+        System.out.println("constructor with named driver class");
+        //given
+
+        //when
+        when(jdbcProperties.getDriver()).thenReturn(DRIVER);
+        when(jdbcProperties.getUrl()).thenReturn(URL);
+        when(jdbcProperties.getUser()).thenReturn(USER);
+        when(jdbcProperties.getPassword()).thenReturn(PASSWORD);
+        dataSource = new JdbcDataSource(jdbcProperties);
+
+        //then
+        assertThat(dataSource.getUrl(), is(URL));
+        assertThat(dataSource.getUsername(), is(USER));
+        assertThat(dataSource.getPassword(), is(PASSWORD));
+    }
+
+    @Test
+    public void testConstructorWithNoDriverClass() {
+        System.out.println("constructor with no driver class");
+        //given
+
+        //when
+        when(jdbcProperties.getUrl()).thenReturn(URL);
+        when(jdbcProperties.getUser()).thenReturn(USER);
+        when(jdbcProperties.getPassword()).thenReturn(PASSWORD);
+        dataSource = new JdbcDataSource(jdbcProperties);
+
+        //then
+        assertThat(dataSource.getUrl(), is(URL));
+        assertThat(dataSource.getUsername(), is(USER));
+        assertThat(dataSource.getPassword(), is(PASSWORD));
+    }
+
+    public static class TestDriver implements Driver {
+
+        @Override
+        public Connection connect(String url, Properties info) throws SQLException {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public boolean acceptsURL(String url) throws SQLException {
+            return url.startsWith("jdbc:test:");
+        }
+
+        @Override
+        public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+            return new DriverPropertyInfo[]{};
+        }
+
+        @Override
+        public int getMajorVersion() {
+            return 1;
+        }
+
+        @Override
+        public int getMinorVersion() {
+            return 0;
+        }
+
+        @Override
+        public boolean jdbcCompliant() {
+            return true;
+        }
+
+        @Override
+        public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+            return mock(Logger.class);
+        }
+
+    }
+}


### PR DESCRIPTION
Simplify use of `JdbcProperties` to create a `DataSource`:

    package foo;

    @Component
    public class FooDataSource extends JdbcDataSource {

        @Autowired
        public FooDataSource(FooJdbcProperties properties) {
            super(properties);
        }
    }