### PR TITLE
Queryable generic search parameter

### DIFF
--- a/src/main/java/net/kemitix/spring/common/Queryable.java
+++ b/src/main/java/net/kemitix/spring/common/Queryable.java
@@ -2,7 +2,7 @@ package net.kemitix.spring.common;
 
 import java.util.List;
 
-public interface Queryable<T> {
+public interface Queryable<S, T> {
 
-    List<T> query(String query);
+    List<T> query(S query);
 }


### PR DESCRIPTION
This allows Search keys to be any object type, not just Strings.